### PR TITLE
feat: add in standard meta from HTML snippets

### DIFF
--- a/files/_partials/header.hbs
+++ b/files/_partials/header.hbs
@@ -4,6 +4,45 @@
     <meta charset="utf-8">
     <meta http-equiv="x-ua-compatible" content="ie=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Cartridge Static HTML</title>
+    {{!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags --}}
+    <title>Cartridge</title>
+    {{!-- SEO meta --}}
+    <meta name="description" content="">
+    <meta name="robots" content="noindex,nofollow"> {{!-- @TODO: change this before production deployment --}}
+    <link rel="canonical" href="https://example.com/page.html">
+
+    {{!-- Favourite icons --}}
+    <link rel="icon" href="path/to/favicon-16.png" sizes="16x16" type="image/png">
+    <link rel="icon" href="path/to/favicon-32.png" sizes="32x32" type="image/png">
+    <link rel="icon" href="path/to/favicon-48.png" sizes="48x48" type="image/png">
+    <link rel="icon" href="path/to/favicon-62.png" sizes="62x62" type="image/png">
+    <link rel="icon" href="path/to/favicon-192.png" sizes="192x192" type="image/png">
+    <link rel="apple-touch-icon" href="path/to/apple-touch-icon.png">
+
+    {{!-- Facebook meta --}}
+    <meta property="fb:app_id" content="123456789">
+    <meta property="og:url" content="https://example.com/page.html">
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="Content Title">
+    <meta property="og:image" content="https://example.com/image.jpg">
+    <meta property="og:description" content="Description Here">
+    <meta property="og:site_name" content="Site Name">
+    <meta property="og:locale" content="en_GB">
+    <meta property="article:author" content="">
+
+    {{!-- Twitter meta --}}
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:site" content="@site_account">
+    <meta name="twitter:creator" content="@individual_account">
+    <meta name="twitter:url" content="https://example.com/page.html">
+    <meta name="twitter:title" content="Content Title">
+    <meta name="twitter:description" content="Content description less than 200 characters">
+    <meta name="twitter:image" content="https://example.com/image.jpg">
+
+    {{!-- Google Plus meta --}}
+    <link href="https://plus.google.com/+YourPage" rel="publisher">
+    <meta itemprop="name" content="Content Title">
+    <meta itemprop="description" content="Content description less than 200 characters">
+    <meta itemprop="image" content="https://example.com/image.jpg">
   </head>
   <body>


### PR DESCRIPTION
## Description
I’ve added in the standard meta from our [HTML-Snippets](https://github.com/code-computerlove/HTML-Snippets) repository so it’s included in every new project.

@tawashley as you added in the partials can you review and merge please :octocat: 
